### PR TITLE
Added SQL data types bigint and xml.  Use system_type_id instead of user_type_id 

### DIFF
--- a/SPToCore/Program.cs
+++ b/SPToCore/Program.cs
@@ -296,6 +296,8 @@ namespace SPToCore
                 return "int" + (isNullable ? "?" : "");
             else if (type == "tinyint")
                 return "Byte" + (isNullable ? "?" : "");
+            else if (type == "bigint")
+                return "Int64" + (isNullable ? "?" : "");
             else if (type.IndexOf("decimal") > -1)
                 return "decimal" + (isNullable ? "?" : "");
             else if (type.IndexOf("nvarchar") > -1)
@@ -309,7 +311,7 @@ namespace SPToCore
             else if (type.IndexOf("datetimeoffset") > -1)
                 return "DateTimeOffset" + (isNullable ? "?" : "");
             else if (type.IndexOf("datetime") > -1)
-                return "DateTime" + (isNullable ? "?" : "");            
+                return "DateTime" + (isNullable ? "?" : "");
             else if (type.IndexOf("date") > -1)
                 return "DateTime" + (isNullable ? "?" : "");
             else if (type == "decimal")
@@ -318,6 +320,8 @@ namespace SPToCore
                 return "bool" + (isNullable ? "?" : "");
             else if (type == "uniqueidentifier")
                 return "Guid" + (isNullable ? "?" : "");
+            else if (type == "xml")
+                return "string";
             else
                 return "WTF?!";                        
 
@@ -333,6 +337,8 @@ namespace SPToCore
                 return "Int16";
             else if (type == "tinyint")
                 return "Byte";
+            else if (type == "bigint")
+                return "Int64";
             else if (type.IndexOf("decimal") > -1)
                 return "Decimal";
             else if (type.IndexOf("nvarchar") > -1)
@@ -346,13 +352,15 @@ namespace SPToCore
             else if (type.IndexOf("datetimeoffset") > -1)
                 return "DateTime";
             else if (type.IndexOf("datetime") > -1)
-                return "DateTime";            
+                return "DateTime";
             else if (type.IndexOf("date") > -1)
                 return "DateTime";
             else if (type == "bit")
                 return "Boolean";
             else if (type == "uniqueidentifier")
                 return "Guid";
+            else if (type == "xml")
+                return "Xml";
             else
                 return "WTF?!";
 
@@ -401,7 +409,7 @@ namespace SPToCore
                     string sql = $@"
                                 SELECT  
                                    'Parameter' = name,  
-                                   'Type'   = type_name(user_type_id),  
+                                   'Type'   = type_name(system_type_id),  
                                    'Length'   = CAST(max_length AS INT),  
                                    'Precision'   = CAST(case when type_name(system_type_id) = 'uniqueidentifier' 
                                               then precision  


### PR DESCRIPTION
Added SQL data types bigint and xml.  Use system_type_id instead of user_type_id because user defined types can have arbitrary names.