### PR TITLE
SPToCoreT4.tt : Fixed problem with obsolete Query method 

### DIFF
--- a/SPToCore/T4/SPToCoreT4.tt
+++ b/SPToCore/T4/SPToCoreT4.tt
@@ -36,7 +36,7 @@ namespace <#=Namespace#>.<#=SolutionDestinationFolder#>
         {            
             // No key            
 <#    foreach (var sp in SpList){ if (sp.Results.Count > 0){#>
-            modelBuilder.Query<<#=                sp.Name#>Result>().HasNoKey();
+            modelBuilder.Entity<<#=                sp.Name#>Result>().HasNoKey();
 <#    }}#>
             //Thanks Valecass!!!
             base.OnModelCreating(modelBuilder);


### PR DESCRIPTION
I have noticed that after command SPToCore.exe generate in DbContext result file a call to a method Query which has been replaced with Entity.

Source: [Microsoft Doc](https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.modelbuilder.query?view=efcore-3.1)