### PR TITLE
smallint should map to short, not int.

### DIFF
--- a/SPToCore/Program.cs
+++ b/SPToCore/Program.cs
@@ -297,7 +297,7 @@ namespace SPToCore
             else if (type == "bigint")
                 return "Int64" + (isNullable ? "?" : "");
             else if (type == "smallint")
-                return "int" + (isNullable ? "?" : "");
+                return "short" + (isNullable ? "?" : "");
             else if (type == "tinyint")
                 return "Byte" + (isNullable ? "?" : "");
             else if (type == "bigint")


### PR DESCRIPTION
I was receiving weird cast error (that int16 could not be cast to int32) due to smallint -> int mapping.

smallint should map to short (int16), not int32.

This should fix such problems.